### PR TITLE
Fix app configuration

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'name' => env('APP_NAME', 'GoogleCalSyncToNition'),
+    'name' => env('APP_NAME', 'GoogleCalSyncToNotion'),
 
     /*
     |--------------------------------------------------------------------------
@@ -256,7 +256,5 @@ return [
     'google_calendar_label_school' => env('GOOGLE_CALENDAR_LABEL_SCHOOL', null),
     'google_calendar_path_to_json'=> env('GOOGLE_CALENDAR_PATH_TO_JSON', null),
 
-    'google_calendar_path_to_json'=> env('GOOGLE_CALENDAR_PATH_TO_JSON', null),
-    'timezone' => env('TIMEZONE', null),
     'sync_max_days' => env('SYNC_MAX_DAYS', 30),
 ];


### PR DESCRIPTION
## Summary
- fix the default app name string
- remove duplicate `google_calendar_path_to_json`
- keep a single timezone setting

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846656c81ec83329e0405f504576eb7