### PR TITLE
Fix docblock in NotionModel test

### DIFF
--- a/tests/Feature/NotionModelTest.php
+++ b/tests/Feature/NotionModelTest.php
@@ -10,7 +10,7 @@ use \App\Models\NotionModel;
 class NotionModelTest extends TestCase
 {
     /**
-     * test for private function validateTodayString.
+     * test for private function validateTargetDate.
      *
      * @return void
      */


### PR DESCRIPTION
## Summary
- correct the `NotionModelTest` docblock to reference `validateTargetDate`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846673055808332bbb2ad4c9949b199