### PR TITLE
Add NotionModel helpers and adjust tests

### DIFF
--- a/app/Models/NotionModel.php
+++ b/app/Models/NotionModel.php
@@ -197,4 +197,49 @@ class NotionModel extends Model
         return $properties;
     }
 
+    /**
+     * Validate that a given value is a date string in YYYYMMDD format.
+     *
+     * @param mixed $targetDate
+     * @return bool
+     */
+    private function validateTargetDate($targetDate)
+    {
+        if (is_null($targetDate)) {
+            return false;
+        }
+
+        return preg_match('/^\d{8}$/', strval($targetDate)) === 1;
+    }
+
+    /**
+     * Extract the page ID from a Notion page URL.
+     *
+     * @param string $pageUrl
+     * @return string|null
+     */
+    private function getPageId($pageUrl)
+    {
+        if (!is_string($pageUrl)) {
+            return null;
+        }
+
+        $parsed = parse_url($pageUrl);
+        if ($parsed === false || !isset($parsed['host']) || !preg_match('/(?:^|\.)notion\.so$/', $parsed['host'])) {
+            return null;
+        }
+
+        if (!isset($parsed['path'])) {
+            return null;
+        }
+
+        $path = trim($parsed['path'], '/');
+        if ($path === '') {
+            return null;
+        }
+
+        $parts = explode('-', $path);
+        return end($parts);
+    }
+
 }

--- a/tests/Feature/NotionModelTest.php
+++ b/tests/Feature/NotionModelTest.php
@@ -19,10 +19,10 @@ class NotionModelTest extends TestCase
         $notion = new NotionModel;
         $method = new \ReflectionMethod($notion, 'validateTargetDate');
         $method->setAccessible(true);
-        $result = $method->invokeArgs($notion, [20211129]);
+        $result = $method->invokeArgs($notion, ["20211129"]);
         $this->assertTrue($result);
 
-        $result = $method->invokeArgs($notion, [123]);
+        $result = $method->invokeArgs($notion, ["123"]);
         $this->assertFalse($result);
 
         // $result = $method->invokeArgs($notion, ["abcdefgh"]);


### PR DESCRIPTION
## Summary
- implement `validateTargetDate` and `getPageId` in `NotionModel`
- update tests to pass date strings

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684668c4f6108332a02582e55e5e8e1b