### PR TITLE
Use TIMEZONE environment variable for scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ SYNC_MAX_DAYS=90
 - `NOTION_DATA_SOURCE_ID` は Notion のデータベース設定画面から取得できます。指定しなくても自動で解決されます。
 - `SYNC_MAX_DAYS` は今日から何日先までの予定を同期するかを制御します。
 
-タイムゾーンを変更したい場合は `config/app.php` の `timezone` を編集してください（デフォルトは `Asia/Ho_Chi_Minh`）。
+タイムゾーンを変更したい場合は `.env` の `TIMEZONE` を編集してください（未設定時のデフォルトは `Asia/Ho_Chi_Minh`）。
 
 ### 6. Google サービスアカウントキーの配置
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,13 +27,13 @@ class Kernel extends ConsoleKernel
         // 個人・仕事用カレンダーは30分毎に起動する
         $schedule->command('command:gcal-sync-notion')
             ->everyThirtyMinutes()
-            ->timezone('Asia/Ho_Chi_Minh')
+            ->timezone(config('app.timezone'))
             ->between('6:00', '23:00');
 
         // 休日カレンダーは月1回だけ起動する
         $schedule->command('command:gcal-sync-notion holiday')
             ->monthly()
-            ->timezone('Asia/Ho_Chi_Minh');
+            ->timezone(config('app.timezone'));
     }
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -68,7 +68,7 @@ return [
     */
 
 //    'timezone' => 'UTC',
-    'timezone' => 'Asia/Ho_Chi_Minh',
+    'timezone' => env('TIMEZONE', 'Asia/Ho_Chi_Minh'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- read the application timezone from the TIMEZONE environment variable
- ensure scheduled commands honour the configured timezone
- document updating the TIMEZONE value in the environment file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908645449e88332a3fb4e6ff6cfb85d