### PR TITLE
Refine BatchGoogleCalSyncNotion feature test fakes

### DIFF
--- a/tests/Feature/BatchGoogleCalSyncNotionTest.php
+++ b/tests/Feature/BatchGoogleCalSyncNotionTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Mail;
+use Symfony\Component\Console\Command\Command;
+use Tests\Support\Fakes\GoogleCalendarModelFake;
+use Tests\Support\Fakes\NotionModelFake;
+use Tests\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class BatchGoogleCalSyncNotionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!class_exists(\App\Models\NotionModel::class, false)) {
+            class_alias(NotionModelFake::class, \App\Models\NotionModel::class);
+        }
+
+        if (!class_exists(\App\Models\GoogleCalendarModel::class, false)) {
+            class_alias(GoogleCalendarModelFake::class, \App\Models\GoogleCalendarModel::class);
+        }
+
+        NotionModelFake::reset();
+        GoogleCalendarModelFake::reset();
+    }
+
+    private function setDefaultCalendarConfig(): void
+    {
+        config()->set('app.google_calendar_id_personal', 'calendar-personal');
+        config()->set('app.google_calendar_label_personal', 'Personal Label');
+
+        config()->set('app.google_calendar_id_business', null);
+        config()->set('app.google_calendar_label_business', 'Business Label');
+
+        config()->set('app.google_calendar_id_school', null);
+        config()->set('app.google_calendar_label_school', 'School Label');
+
+        config()->set('app.google_calendar_id_holiday', 'calendar-holiday');
+        config()->set('app.google_calendar_label_holiday', 'Holiday Label');
+
+        config()->set('app.sync_max_days', 0);
+    }
+
+    public function test_command_sends_mail_when_new_events_synced(): void
+    {
+        $this->setDefaultCalendarConfig();
+        config()->set('app.sync_report_mail_to', 'notify@example.com');
+
+        $event = (object) ['id' => 'event-1'];
+
+        NotionModelFake::$upcomingEventsReturn = collect();
+        NotionModelFake::$collectionsReturn = [
+            'event-1' => collect(),
+        ];
+        NotionModelFake::$registResults = [
+            'event-1' => true,
+        ];
+
+        GoogleCalendarModelFake::$eventLists = [
+            'calendar-personal' => [$event],
+        ];
+
+        Mail::fake();
+
+        $this->artisan('command:gcal-sync-notion')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertSame(1, NotionModelFake::$getUpcomingCalls);
+        $this->assertSame(['event-1'], NotionModelFake::$getCollectionsCalls);
+        $this->assertCount(1, NotionModelFake::$registCalls);
+        $this->assertSame([], NotionModelFake::$deleteCalls);
+
+        Mail::assertSent(function ($message) {
+            $original = method_exists($message, 'getOriginalMessage')
+                ? $message->getOriginalMessage()
+                : $message->getSymfonyMessage();
+
+            $subject = method_exists($original, 'getSubject') ? $original->getSubject() : null;
+            $body = null;
+            if (method_exists($original, 'getTextBody')) {
+                $body = $original->getTextBody();
+            } elseif (method_exists($original, 'getBody')) {
+                $bodyObject = $original->getBody();
+                if (method_exists($bodyObject, 'bodyToString')) {
+                    $body = $bodyObject->bodyToString();
+                } elseif (method_exists($bodyObject, '__toString')) {
+                    $body = (string) $bodyObject;
+                }
+            }
+
+            return $subject === 'Notion同期レポート'
+                && is_string($body)
+                && str_contains($body, 'Personal Label: 1件')
+                && str_contains($body, '以上の予定をNotionデータベースに同期しました。');
+        });
+    }
+
+    public function test_command_skips_mail_when_only_existing_events(): void
+    {
+        $this->setDefaultCalendarConfig();
+        config()->set('app.sync_report_mail_to', 'notify@example.com');
+
+        $event = (object) ['id' => 'event-1'];
+
+        NotionModelFake::$upcomingEventsReturn = collect();
+        NotionModelFake::$collectionsReturn = [
+            'event-1' => collect(['existing']),
+        ];
+
+        GoogleCalendarModelFake::$eventLists = [
+            'calendar-personal' => [$event],
+        ];
+
+        Mail::fake();
+
+        $this->artisan('command:gcal-sync-notion')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertSame(1, NotionModelFake::$getUpcomingCalls);
+        $this->assertSame(['event-1'], NotionModelFake::$getCollectionsCalls);
+        $this->assertSame([], NotionModelFake::$registCalls);
+        $this->assertSame([], NotionModelFake::$deleteCalls);
+
+        Mail::assertNothingSent();
+    }
+
+    public function test_command_does_not_delete_events_in_holiday_mode(): void
+    {
+        $this->setDefaultCalendarConfig();
+        config()->set('app.sync_report_mail_to', 'notify@example.com');
+
+        $event = (object) ['id' => 'holiday-event'];
+
+        NotionModelFake::$collectionsReturn = [
+            'holiday-event' => collect(),
+        ];
+        NotionModelFake::$registResults = [
+            'holiday-event' => true,
+        ];
+
+        GoogleCalendarModelFake::$eventLists = [
+            'calendar-holiday' => [$event],
+        ];
+
+        Mail::fake();
+
+        $this->artisan('command:gcal-sync-notion', ['mode' => 'holiday'])
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertSame(0, NotionModelFake::$getUpcomingCalls);
+        $this->assertSame(['holiday-event'], NotionModelFake::$getCollectionsCalls);
+        $this->assertCount(1, NotionModelFake::$registCalls);
+        $this->assertSame([], NotionModelFake::$deleteCalls);
+
+        Mail::assertSent(function ($message) {
+            $original = method_exists($message, 'getOriginalMessage')
+                ? $message->getOriginalMessage()
+                : $message->getSymfonyMessage();
+
+            $subject = method_exists($original, 'getSubject') ? $original->getSubject() : null;
+            $body = null;
+            if (method_exists($original, 'getTextBody')) {
+                $body = $original->getTextBody();
+            } elseif (method_exists($original, 'getBody')) {
+                $bodyObject = $original->getBody();
+                if (method_exists($bodyObject, 'bodyToString')) {
+                    $body = $bodyObject->bodyToString();
+                } elseif (method_exists($bodyObject, '__toString')) {
+                    $body = (string) $bodyObject;
+                }
+            }
+
+            return $subject === 'Notion同期レポート'
+                && is_string($body)
+                && str_contains($body, 'Holiday Label: 1件');
+        });
+    }
+
+    public function test_command_deletes_orphaned_notion_events(): void
+    {
+        $this->setDefaultCalendarConfig();
+        config()->set('app.sync_report_mail_to', 'notify@example.com');
+
+        $notionEvents = collect([
+            [
+                'id' => 'notion-event-1',
+                'properties' => [
+                    'googleCalendarId' => [
+                        'rich_text' => [
+                            [
+                                'text' => [
+                                    'content' => 'missing-google-event',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        NotionModelFake::$upcomingEventsReturn = $notionEvents;
+        NotionModelFake::$collectionsReturn = [
+            'event-existing' => collect(['existing']),
+        ];
+
+        GoogleCalendarModelFake::$eventLists = [
+            'calendar-personal' => [(object) ['id' => 'event-existing']],
+        ];
+
+        Mail::fake();
+
+        $this->artisan('command:gcal-sync-notion')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertSame(1, NotionModelFake::$getUpcomingCalls);
+        $this->assertSame(['event-existing'], NotionModelFake::$getCollectionsCalls);
+        $this->assertSame([], NotionModelFake::$registCalls);
+        $this->assertSame(['notion-event-1'], NotionModelFake::$deleteCalls);
+
+        Mail::assertNothingSent();
+    }
+}

--- a/tests/Support/Fakes/GoogleCalendarModelFake.php
+++ b/tests/Support/Fakes/GoogleCalendarModelFake.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+class GoogleCalendarModelFake
+{
+    public static array $eventLists = [];
+    public static array $getListCalls = [];
+    public static array $isUserParticipatingResults = [];
+    public static array $isUserParticipatingCalls = [];
+
+    public static function reset(): void
+    {
+        self::$eventLists = [];
+        self::$getListCalls = [];
+        self::$isUserParticipatingResults = [];
+        self::$isUserParticipatingCalls = [];
+    }
+
+    public function getGoogleCalendarEventList($start, $end, $calendarId)
+    {
+        self::$getListCalls[] = [$start, $end, $calendarId];
+
+        return self::$eventLists[$calendarId] ?? [];
+    }
+
+    public function isUserParticipating(object $event): bool
+    {
+        self::$isUserParticipatingCalls[] = $event->id;
+
+        if (array_key_exists($event->id, self::$isUserParticipatingResults)) {
+            $result = self::$isUserParticipatingResults[$event->id];
+            return is_callable($result) ? (bool) $result($event) : (bool) $result;
+        }
+
+        return true;
+    }
+}

--- a/tests/Support/Fakes/NotionModelFake.php
+++ b/tests/Support/Fakes/NotionModelFake.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Support\Fakes;
+
+use Illuminate\Support\Collection;
+
+class NotionModelFake
+{
+    public static Collection $upcomingEventsReturn;
+    public static array $collectionsReturn = [];
+    public static array $registResults = [];
+    public static array $deleteCalls = [];
+    public static int $getUpcomingCalls = 0;
+    public static array $getUpcomingArgs = [];
+    public static array $getCollectionsCalls = [];
+    public static array $registCalls = [];
+
+    public static function reset(): void
+    {
+        self::$upcomingEventsReturn = collect();
+        self::$collectionsReturn = [];
+        self::$registResults = [];
+        self::$deleteCalls = [];
+        self::$getUpcomingCalls = 0;
+        self::$getUpcomingArgs = [];
+        self::$getCollectionsCalls = [];
+        self::$registCalls = [];
+    }
+
+    public function getUpcomingNotionEvents($start, $end, $excludeLabels)
+    {
+        self::$getUpcomingCalls++;
+        self::$getUpcomingArgs[] = [$start, $end, $excludeLabels];
+
+        return self::$upcomingEventsReturn;
+    }
+
+    public function getCollectionsFromNotion(string $eventId)
+    {
+        self::$getCollectionsCalls[] = $eventId;
+
+        return self::$collectionsReturn[$eventId] ?? collect();
+    }
+
+    public function registNotionEvent(object $event, string $label)
+    {
+        self::$registCalls[] = [$event, $label];
+
+        $result = self::$registResults[$event->id] ?? false;
+        if (is_callable($result)) {
+            return $result($event, $label);
+        }
+
+        return (bool) $result;
+    }
+
+    public function deleteNotionEvent(string $pageId): bool
+    {
+        self::$deleteCalls[] = $pageId;
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- replace Mockery overload usage in `BatchGoogleCalSyncNotionTest` with lightweight fake model implementations
- reset fake state per test run and isolate processes to avoid leaking aliases to the wider suite
- add explicit assertions for fake call counts and behaviours to keep coverage of sync paths and mail notifications

## Testing
- ⚠️ `./vendor/bin/phpunit --filter BatchGoogleCalSyncNotionTest` *(fails because vendor binaries are unavailable in this environment)*
- ✅ `php -l tests/Feature/BatchGoogleCalSyncNotionTest.php`
- ✅ `php -l tests/Support/Fakes/NotionModelFake.php`
- ✅ `php -l tests/Support/Fakes/GoogleCalendarModelFake.php`


------
https://chatgpt.com/codex/tasks/task_e_6909c0eab7588332b9ac18546dac19e0