### PR TITLE
Add unit tests for GoogleCalendarModel participation detection

### DIFF
--- a/tests/Unit/GoogleCalendarModelTest.php
+++ b/tests/Unit/GoogleCalendarModelTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\GoogleCalendarModel;
+use stdClass;
+use Tests\TestCase;
+
+class GoogleCalendarModelTest extends TestCase
+{
+    private function makeEventWithAttendees(array $attendees): stdClass
+    {
+        $event = new stdClass();
+        $event->attendees = $attendees;
+
+        return $event;
+    }
+
+    public function test_isUserParticipating_returns_true_when_self_accepted(): void
+    {
+        $attendee = new stdClass();
+        $attendee->self = true;
+        $attendee->responseStatus = 'accepted';
+
+        $event = $this->makeEventWithAttendees([$attendee]);
+
+        $model = new GoogleCalendarModel();
+        $this->assertTrue($model->isUserParticipating($event));
+    }
+
+    public function test_isUserParticipating_returns_true_when_self_needs_action(): void
+    {
+        $attendee = new stdClass();
+        $attendee->self = true;
+        $attendee->responseStatus = 'needsAction';
+
+        $event = $this->makeEventWithAttendees([$attendee]);
+
+        $model = new GoogleCalendarModel();
+        $this->assertTrue($model->isUserParticipating($event));
+    }
+
+    public function test_isUserParticipating_returns_false_when_self_declined(): void
+    {
+        $attendee = new stdClass();
+        $attendee->self = true;
+        $attendee->responseStatus = 'declined';
+
+        $event = $this->makeEventWithAttendees([$attendee]);
+
+        $model = new GoogleCalendarModel();
+        $this->assertFalse($model->isUserParticipating($event));
+    }
+
+    public function test_isUserParticipating_returns_false_when_attendees_missing(): void
+    {
+        $event = new stdClass();
+
+        $model = new GoogleCalendarModel();
+        $this->assertFalse($model->isUserParticipating($event));
+    }
+
+    public function test_isUserParticipating_returns_false_when_self_flag_missing(): void
+    {
+        $attendee = new stdClass();
+        $attendee->responseStatus = 'accepted';
+
+        $event = $this->makeEventWithAttendees([$attendee]);
+
+        $model = new GoogleCalendarModel();
+        $this->assertFalse($model->isUserParticipating($event));
+    }
+
+    public function test_isUserParticipating_checks_each_attendee_until_self_found(): void
+    {
+        $other = new stdClass();
+        $other->self = false;
+        $other->responseStatus = 'accepted';
+
+        $self = new stdClass();
+        $self->self = true;
+        $self->responseStatus = 'accepted';
+
+        $event = $this->makeEventWithAttendees([$other, $self]);
+
+        $model = new GoogleCalendarModel();
+        $this->assertTrue($model->isUserParticipating($event));
+    }
+}


### PR DESCRIPTION
## Summary
- add a unit test suite for GoogleCalendarModel::isUserParticipating
- verify accepted and needsAction responses return true and declined returns false
- cover boundary cases where attendees data is missing or self attendee is not first in the list

## Testing
- ⚠️ `./vendor/bin/phpunit --filter GoogleCalendarModelTest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6909c62774448332862fa27b654b68e0