### PR TITLE
Type-hint Mail assertions in BatchGoogleCalSyncNotionTest

### DIFF
--- a/tests/Feature/BatchGoogleCalSyncNotionTest.php
+++ b/tests/Feature/BatchGoogleCalSyncNotionTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Mail\Mailables\SentMessage;
 use Illuminate\Support\Facades\Mail;
 use Symfony\Component\Console\Command\Command;
 use Tests\Support\Fakes\GoogleCalendarModelFake;
@@ -76,7 +77,7 @@ class BatchGoogleCalSyncNotionTest extends TestCase
         $this->assertCount(1, NotionModelFake::$registCalls);
         $this->assertSame([], NotionModelFake::$deleteCalls);
 
-        Mail::assertSent(function ($message) {
+        Mail::assertSent(function (SentMessage $message) {
             $original = method_exists($message, 'getOriginalMessage')
                 ? $message->getOriginalMessage()
                 : $message->getSymfonyMessage();
@@ -158,7 +159,7 @@ class BatchGoogleCalSyncNotionTest extends TestCase
         $this->assertCount(1, NotionModelFake::$registCalls);
         $this->assertSame([], NotionModelFake::$deleteCalls);
 
-        Mail::assertSent(function ($message) {
+        Mail::assertSent(function (SentMessage $message) {
             $original = method_exists($message, 'getOriginalMessage')
                 ? $message->getOriginalMessage()
                 : $message->getSymfonyMessage();


### PR DESCRIPTION
## Summary
- import `Illuminate\Mail\Mailables\SentMessage` in `BatchGoogleCalSyncNotionTest`
- type-hint the `Mail::assertSent` callbacks to accept `SentMessage`

## Testing
- php artisan test --filter=BatchGoogleCalSyncNotionTest *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_6909c77c02d48332b97063d7fcb5c57e