### PR TITLE
Add PHPUnit attributes to BatchGoogleCalSyncNotionTest

### DIFF
--- a/tests/Feature/BatchGoogleCalSyncNotionTest.php
+++ b/tests/Feature/BatchGoogleCalSyncNotionTest.php
@@ -4,15 +4,15 @@ namespace Tests\Feature;
 
 use Illuminate\Mail\Mailables\SentMessage;
 use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\Console\Command\Command;
 use Tests\Support\Fakes\GoogleCalendarModelFake;
 use Tests\Support\Fakes\NotionModelFake;
 use Tests\TestCase;
 
-/**
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
- */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState(false)]
 class BatchGoogleCalSyncNotionTest extends TestCase
 {
     protected function setUp(): void


### PR DESCRIPTION
## Summary
- import the RunTestsInSeparateProcesses and PreserveGlobalState PHPUnit attributes
- apply the attributes to BatchGoogleCalSyncNotionTest in place of docblock annotations

## Testing
- phpunit --filter BatchGoogleCalSyncNotionTest *(fails: phpunit executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6909cfc56c608332b2f20fd51e0add23