### PR TITLE
Add sync window assertion for Notion upcoming events

### DIFF
--- a/tests/Feature/BatchGoogleCalSyncNotionTest.php
+++ b/tests/Feature/BatchGoogleCalSyncNotionTest.php
@@ -52,6 +52,7 @@ class BatchGoogleCalSyncNotionTest extends TestCase
     {
         $this->setDefaultCalendarConfig();
         config()->set('app.sync_report_mail_to', 'notify@example.com');
+        config()->set('app.sync_max_days', 3);
 
         $event = (object) [
             'id' => 'event-1',
@@ -77,6 +78,11 @@ class BatchGoogleCalSyncNotionTest extends TestCase
             ->assertExitCode(Command::SUCCESS);
 
         $this->assertSame(1, NotionModelFake::$getUpcomingCalls);
+        $expectedStart = date('Y-m-d');
+        $expectedEnd = date('Y-m-d', strtotime('+3 day'));
+        $this->assertSame([
+            [$expectedStart, $expectedEnd, ['Holiday Label']],
+        ], NotionModelFake::$getUpcomingArgs);
         $this->assertSame(['event-1'], NotionModelFake::$getCollectionsCalls);
         $this->assertCount(1, NotionModelFake::$registCalls);
         $this->assertSame([], NotionModelFake::$deleteCalls);


### PR DESCRIPTION
## Summary
- configure the sync window in the mail-notification test to cover a non-zero number of days
- assert the Notion model fake receives the expected start, end, and exclusion label arguments when fetching upcoming events

## Testing
- vendor/bin/phpunit --filter BatchGoogleCalSyncNotionTest *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_690ac9e1c83c8332b561da44f4ca1440