### PR TITLE
Skip empty Google calendar IDs when syncing

### DIFF
--- a/app/Console/Commands/BatchGoogleCalSyncNotion.php
+++ b/app/Console/Commands/BatchGoogleCalSyncNotion.php
@@ -109,9 +109,9 @@ class BatchGoogleCalSyncNotion extends Command
 
         // 各Google Calenterから指定範囲のイベントを取得
         foreach (array_keys($calendar_list) as $key){
-            if(is_null($calendar_list[$key]['calendar_id'])){
+            if(empty($calendar_list[$key]['calendar_id'])){
                 continue;
-            }                
+            }
 
             $events = [];
             $googlecal = new GoogleCalendarModel;

--- a/tests/Feature/BatchGoogleCalSyncNotionTest.php
+++ b/tests/Feature/BatchGoogleCalSyncNotionTest.php
@@ -262,4 +262,21 @@ class BatchGoogleCalSyncNotionTest extends TestCase
 
         Mail::assertNothingSent();
     }
+
+    public function test_command_skips_calendars_when_id_is_empty_string(): void
+    {
+        $this->setDefaultCalendarConfig();
+        config()->set('app.google_calendar_id_personal', '');
+        config()->set('app.sync_report_mail_to', 'notify@example.com');
+
+        NotionModelFake::$upcomingEventsReturn = collect();
+
+        Mail::fake();
+
+        $this->artisan('command:gcal-sync-notion')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertSame([], GoogleCalendarModelFake::$getListCalls);
+        Mail::assertNothingSent();
+    }
 }


### PR DESCRIPTION
## Summary
- ensure the sync command ignores Google calendars whose identifier is empty
- add a regression test to guard against invoking the Google Calendar client for blank identifiers

## Testing
- not run (composer install requires GitHub authentication in this environment)


------
https://chatgpt.com/codex/tasks/task_e_690acf2784a0833280f483da7007fb29