### PR TITLE
Ensure SyncReportFormatter uses Unix newlines

### DIFF
--- a/app/Support/SyncReportFormatter.php
+++ b/app/Support/SyncReportFormatter.php
@@ -30,6 +30,6 @@ class SyncReportFormatter
 
         $lines[] = '以上の予定をNotionデータベースに同期しました。';
 
-        return implode(PHP_EOL, $lines);
+        return implode("\n", $lines);
     }
 }


### PR DESCRIPTION
## Summary
- replace PHP_EOL with a literal newline when formatting sync report text

## Testing
- ⚠️ `php artisan test --filter=BatchGoogleCalSyncNotionTest::test_command_sends_slack_dm_when_enabled` *(fails: composer install requires GitHub token to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690b05711cbc833293b77b4d4cd14bf6