### PR TITLE
Include deleted events in sync notifications

### DIFF
--- a/app/Support/SyncReportFormatter.php
+++ b/app/Support/SyncReportFormatter.php
@@ -6,7 +6,7 @@ class SyncReportFormatter
 {
     /**
      * @param array<string, int> $totals
-     * @param array<string, array<int, array{start: string, summary: string}>> $details
+     * @param array<string, array<int, array{action?: string, start: string, summary: string}>> $details
      */
     public static function formatText(array $totals, array $details): string
     {
@@ -22,6 +22,12 @@ class SyncReportFormatter
                 $detail = trim(trim((string) $start) . ' ' . trim((string) $summary));
                 if ($detail === '') {
                     $detail = '(詳細なし)';
+                }
+
+                $action = $event['action'] ?? '';
+                if ($action !== '') {
+                    $lines[] = sprintf('  - %s：%s', $action, $detail);
+                    continue;
                 }
 
                 $lines[] = sprintf('  - %s', $detail);


### PR DESCRIPTION
## Summary
- include deleted Notion events in sync counts and details for reports
- record action, start time, and summary for both additions and deletions to Slack and mail messages
- format sync report lines with action labels to match expected notification style

## Testing
- phpunit *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e727aa4488332abba68a287544010)