### PR TITLE
NotionModel の未使用プライベートヘルパーを削除

### DIFF
--- a/app/Models/NotionModel.php
+++ b/app/Models/NotionModel.php
@@ -286,49 +286,4 @@ class NotionModel extends Model
         return $properties;
     }
 
-    /**
-     * Validate that a given value is a date string in YYYYMMDD format.
-     *
-     * @param mixed $targetDate
-     * @return bool
-     */
-    private function validateTargetDate($targetDate)
-    {
-        if (is_null($targetDate)) {
-            return false;
-        }
-
-        return preg_match('/^\d{8}$/', strval($targetDate)) === 1;
-    }
-
-    /**
-     * Extract the page ID from a Notion page URL.
-     *
-     * @param string $pageUrl
-     * @return string|null
-     */
-    private function getPageId($pageUrl)
-    {
-        if (!is_string($pageUrl)) {
-            return null;
-        }
-
-        $parsed = parse_url($pageUrl);
-        if ($parsed === false || !isset($parsed['host']) || !preg_match('/(?:^|\.)notion\.so$/', $parsed['host'])) {
-            return null;
-        }
-
-        if (!isset($parsed['path'])) {
-            return null;
-        }
-
-        $path = trim($parsed['path'], '/');
-        if ($path === '') {
-            return null;
-        }
-
-        $parts = explode('-', $path);
-        return end($parts);
-    }
-
 }


### PR DESCRIPTION
### Motivation
- `NotionModel` に定義されていたいくつかのプライベートヘルパーが参照されておらず、コードの保守性を下げていたため削除しました。 
- 未使用のメソッドを除くことでクラスの責務を明確化し、将来の誤用を防止します。

### Description
- `app/Models/NotionModel.php` から未使用のプライベートメソッド `validateTargetDate` を削除しました.
- 同ファイルから未使用のプライベートメソッド `getPageId` を削除しました.
- 上記削除以外のロジックや公開 API に変更は加えていません.

### Testing
- 自動テストは実行していません。
- リファクタ前後で参照検索によりこれらメソッドがプロジェクト内で使用されていないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696469f10af883329e39c2c3f22ead52)