### PR TITLE
Notion削除判定でGoogleイベントの開始日時を比較する

### DIFF
--- a/app/Console/Commands/BatchGoogleCalSyncNotion.php
+++ b/app/Console/Commands/BatchGoogleCalSyncNotion.php
@@ -111,6 +111,7 @@ class BatchGoogleCalSyncNotion extends Command
             }
 
             $googleEventIds = [];
+            $googleEventStartsById = [];
             $events = [];
             $googlecal = new GoogleCalendarModel;
 
@@ -131,6 +132,7 @@ class BatchGoogleCalSyncNotion extends Command
 
                 // イベントIDを配列に格納
                 $googleEventIds[] = $event->id;
+                $googleEventStartsById[$event->id] = $this->formatEventStart($event);
 
                 // このイベントがNotionに登録されているか検索
                 try{
@@ -196,7 +198,11 @@ class BatchGoogleCalSyncNotion extends Command
                         continue;
                     }
 
-                    if (!in_array($googleCalendarId, $googleEventIds, true)) {
+                    $googleEventStart = $googleEventStartsById[$googleCalendarId] ?? null;
+                    $notionEventStart = $this->formatNotionEventStart($notionEvent);
+
+                    if (!in_array($googleCalendarId, $googleEventIds, true)
+                        || $googleEventStart !== $notionEventStart) {
                         try {
                             $notions->deleteNotionEvent($notionEvent['id']);
                         } catch (\Exception $e) {


### PR DESCRIPTION
### Motivation
- Google側で開始日時が変更されたイベントをNotion側でも正しく削除対象に含めるため、ID存在判定に加えて開始日時の差分も判定する。既存のフォーマット関数で正規化して比較することで日付形式の揺れを避ける。 

### Description
- `app/Console/Commands/BatchGoogleCalSyncNotion.php` に ` $googleEventStartsById` マップを追加して、Googleイベント取得ループ内で `[$event->id => $this->formatEventStart($event)]` を格納するようにした。 
- Notion削除判定内で `formatNotionEventStart($notionEvent)` と ` $googleEventStartsById[$googleCalendarId]` を比較し、IDが存在しない場合と開始日時が一致しない場合の両方で削除処理を行うようにした。 
- 既存の削除ログ記録（`$actionDetails`／`$actionCountsByLabel`）は維持している。 

### Testing
- 自動化されたテストは実行していない。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a0d7459d083329b3137f4b7a4bbf8)