### PR TITLE
Notionページ削除をアーカイブ化（archived=true）に変更

### DIFF
--- a/app/Models/NotionModel.php
+++ b/app/Models/NotionModel.php
@@ -202,7 +202,11 @@ class NotionModel extends Model
      */
     public function deleteNotionEvent(string $eventId)
     {
-        $response = $this->client->delete('blocks/' . $eventId);
+        $response = $this->client->patch('pages/' . $eventId, [
+            'json' => [
+                'archived' => true,
+            ],
+        ]);
 
         return $response->getStatusCode() === 200;
     }


### PR DESCRIPTION
### Motivation
- Notion のページ削除処理で `DELETE blocks/{id}` を使っていましたが、Notion の仕様に沿ってページは `pages/{id}` を `archived: true` にすることで削除（アーカイブ）すべきため修正しました。

### Description
- `NotionModel::deleteNotionEvent` を更新し、`$this->client->delete('blocks/' . $eventId)` から `PATCH pages/{id}` に `json` ペイロード `['archived' => true]` を送る実装に変更しました。

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981743d737c83328fb2097d3e73080d)