### PR TITLE
SyncReportFormatter のアクション明細の書式を修正（単体テスト追加）

### DIFF
--- a/app/Support/SyncReportFormatter.php
+++ b/app/Support/SyncReportFormatter.php
@@ -26,7 +26,7 @@ class SyncReportFormatter
 
                 $action = $event['action'] ?? '';
                 if ($action !== '') {
-                    $lines[] = sprintf('  - %s ) %s', $action, $detail);
+                    $lines[] = sprintf('  - (%s) %s', $action, $detail);
                     continue;
                 }
 

--- a/tests/Unit/SyncReportFormatterTest.php
+++ b/tests/Unit/SyncReportFormatterTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\SyncReportFormatter;
+use Tests\TestCase;
+
+class SyncReportFormatterTest extends TestCase
+{
+    public function test_format_text_formats_action_with_parentheses(): void
+    {
+        $text = SyncReportFormatter::formatText([
+            '仕事' => 1,
+        ], [
+            '仕事' => [
+                [
+                    'action' => '追加',
+                    'start' => '2026-01-01 09:00',
+                    'summary' => '定例会議',
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('  - (追加) 2026-01-01 09:00 定例会議', $text);
+        $this->assertStringNotContainsString('  - 追加 ) 2026-01-01 09:00 定例会議', $text);
+    }
+}


### PR DESCRIPTION
### Motivation
- Slack やメールで送信する同期レポートの明細行でアクション部分が誤って `追加 ) ...` のように出力されており可読性を損なっていたため修正しました。

### Description
- `app/Support/SyncReportFormatter.php` のアクション出力を `sprintf('  - (%s) %s', $action, $detail)` に変更して `(<action>) <detail>` 形式に統一しました。
- 再発防止のため `tests/Unit/SyncReportFormatterTest.php` を追加し、アクション付き明細のフォーマットが正しく出力されることを検証するようにしました。

### Testing
- `php -l app/Support/SyncReportFormatter.php` と `php -l tests/Unit/SyncReportFormatterTest.php` を実行して両ファイルの構文チェックは成功しました。 
- `vendor/bin/phpunit --filter SyncReportFormatterTest` の実行は環境で `vendor/bin/phpunit` が存在せず依存取得ができなかったため実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae379a8a708332be2346eecbf9f6a0)