### PR TITLE
削除同期を通知件数と明細に反映

### DIFF
--- a/app/Console/Commands/BatchGoogleCalSyncNotion.php
+++ b/app/Console/Commands/BatchGoogleCalSyncNotion.php
@@ -83,6 +83,7 @@ class BatchGoogleCalSyncNotion extends Command
         }
 
         $syncCountsByLabel = [];
+        $deleteCountsByLabel = [];
         $syncDetails = [];
 
         $notions = new NotionModel;
@@ -207,20 +208,37 @@ class BatchGoogleCalSyncNotion extends Command
                     if (!in_array($googleCalendarId, $googleEventIds, true)
                         || $googleEventStart !== $notionEventStart) {
                         try {
-                            $notions->deleteNotionEvent($notionEvent['id']);
+                            $deleted = $notions->deleteNotionEvent($notionEvent['id']);
                         } catch (\Exception $e) {
                             report($e);
                             return Command::FAILURE;
+                        }
+
+                        if ($deleted) {
+                            $calendarLabel = $targetLabel !== '' ? $targetLabel : ($key ?? '');
+                            $deleteCountsByLabel[$calendarLabel] = ($deleteCountsByLabel[$calendarLabel] ?? 0) + 1;
+                            if (!array_key_exists($calendarLabel, $syncDetails)) {
+                                $syncDetails[$calendarLabel] = [];
+                            }
+
+                            $syncDetails[$calendarLabel][] = [
+                                'action' => '削除',
+                                'start' => $notionEventStart,
+                                'summary' => $this->extractNotionSummary($notionEvent),
+                            ];
                         }
                     }
                 }
             }
         }
 
-        $totalActions = array_sum($syncCountsByLabel);
+        $totalActions = array_sum($syncCountsByLabel) + array_sum($deleteCountsByLabel);
 
         if ($totalActions > 0) {
-            $totals = $syncCountsByLabel;
+            $totals = [];
+            foreach (array_unique(array_merge(array_keys($syncCountsByLabel), array_keys($deleteCountsByLabel))) as $label) {
+                $totals[$label] = ($syncCountsByLabel[$label] ?? 0) + ($deleteCountsByLabel[$label] ?? 0);
+            }
 
             if (!empty($totals)) {
                 $bodyText = SyncReportFormatter::formatText($totals, $syncDetails);

--- a/tests/Feature/BatchGoogleCalSyncNotionTest.php
+++ b/tests/Feature/BatchGoogleCalSyncNotionTest.php
@@ -296,6 +296,21 @@ class BatchGoogleCalSyncNotionTest extends TestCase
             [
                 'id' => 'notion-event-1',
                 'properties' => [
+                    'ジャンル' => [
+                        'multi_select' => [
+                            ['name' => 'Personal Label'],
+                        ],
+                    ],
+                    'Name' => [
+                        'title' => [
+                            ['plain_text' => 'Stale Notion Event'],
+                        ],
+                    ],
+                    'Date' => [
+                        'date' => [
+                            'start' => '2024-05-11T10:00:00+09:00',
+                        ],
+                    ],
                     'googleCalendarId' => [
                         'rich_text' => [
                             [
@@ -327,8 +342,25 @@ class BatchGoogleCalSyncNotionTest extends TestCase
         $this->assertSame(['event-existing'], NotionModelFake::$getCollectionsCalls);
         $this->assertSame([], NotionModelFake::$registCalls);
         $this->assertSame(['notion-event-1'], NotionModelFake::$deleteCalls);
+        Mail::assertSent(SyncReportMail::class, function (SyncReportMail $mail) {
+            $mail->build();
 
-        Mail::assertNothingSent();
+            $rendered = $mail->render();
+
+            return $mail->totals === ['Personal Label' => 1]
+                && $mail->details === [
+                    'Personal Label' => [
+                        [
+                            'action' => '削除',
+                            'start' => '2024-05-11 10:00',
+                            'summary' => 'Stale Notion Event',
+                        ],
+                    ],
+                ]
+                && is_string($rendered)
+                && str_contains($rendered, 'Personal Label: 1件')
+                && str_contains($rendered, '  - (削除) 2024-05-11 10:00 Stale Notion Event');
+        });
     }
 
     public function test_command_skips_notion_events_when_google_calendar_id_missing(): void

--- a/tests/Unit/SyncReportFormatterTest.php
+++ b/tests/Unit/SyncReportFormatterTest.php
@@ -24,4 +24,21 @@ class SyncReportFormatterTest extends TestCase
         $this->assertStringContainsString('  - (追加) 2026-01-01 09:00 定例会議', $text);
         $this->assertStringNotContainsString('  - 追加 ) 2026-01-01 09:00 定例会議', $text);
     }
+
+    public function test_format_text_displays_delete_action_with_parentheses(): void
+    {
+        $text = SyncReportFormatter::formatText([
+            '個人' => 1,
+        ], [
+            '個人' => [
+                [
+                    'action' => '削除',
+                    'start' => '2026-01-02 10:00',
+                    'summary' => '不要な予定',
+                ],
+            ],
+        ]);
+
+        $this->assertStringContainsString('  - (削除) 2026-01-02 10:00 不要な予定', $text);
+    }
 }


### PR DESCRIPTION
### Motivation
- Notion側で孤立したイベントを削除した際に、その削除件数と明細を通知（メール／Slack）に反映して可視化するための変更です。
- 通知の判定を「追加のみ」から「追加＋削除の合計」に変更して、削除のみ発生した場合でもレポートを送信できるようにします。

### Description
- 削除件数をラベル単位で集計するために変数`$deleteCountsByLabel`を導入し、Notion削除成功時にインクリメントする処理を追加しました。 
- 削除明細を`$syncDetails`に追記し、明細には`action => '削除'`、`start`、`summary`を格納するようにしました。 
- 通知判定と通知へ渡す`totals`を追加件数だけでなく`array_sum($syncCountsByLabel) + array_sum($deleteCountsByLabel)`で判定・合算するように変更し、`totals`はラベルごとに追加＋削除を合算した値にしています。 
- テストを更新し、Featureテストの`test_command_deletes_orphaned_notion_events`で削除発生時に`SyncReportMail`が送信されることと`totals`/`details`に削除情報が含まれることを検証するように変更し、Unitテスト`SyncReportFormatterTest`に`(削除)`表示の検証を追加しました。

### Testing
- `php -l app/Console/Commands/BatchGoogleCalSyncNotion.php`は構文チェックに成功しました。 
- `php -l tests/Feature/BatchGoogleCalSyncNotionTest.php`および`php -l tests/Unit/SyncReportFormatterTest.php`は構文チェックに成功しました。 
- `php artisan test --filter=SyncReportFormatterTest`は`vendor/autoload.php`が存在しない環境のため実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5ee1529e883329937fbcd1e9fe3a5)