### PR TITLE
過去のNotion予定が同期時に削除される不具合を修正

### DIFF
--- a/app/Models/NotionModel.php
+++ b/app/Models/NotionModel.php
@@ -130,6 +130,12 @@ class NotionModel extends Model
             [
                 'property' => 'Date',
                 'date' => [
+                    'on_or_after' => $start_date,
+                ],
+            ],
+            [
+                'property' => 'Date',
+                'date' => [
                     'on_or_before' => $end_date,
                 ],
             ],


### PR DESCRIPTION
### Motivation
- 同期処理でNotionから取得しているイベントが終了日のみでフィルタされていたため、同期対象期間より前の過去予定まで取得されてGoogle側に存在しないとして削除されてしまう不具合を解消するため。 

### Description
- `app/Models/NotionModel.php` の `getUpcomingNotionEvents` に `Date on_or_after $start_date` フィルタを追加して、取得範囲を開始日〜終了日に制限するよう変更した。 

### Testing
- `php artisan test tests/Unit/NotionModelHttpTest.php tests/Feature/BatchGoogleCalSyncNotionTest.php` を実行しようとしたが、`vendor/autoload.php` が存在しないため依存関係が満たされずテスト実行できなかった（実行不可）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2c6b283e08332a21550cc828b95cd)