### PR TITLE
Notion の期間重なり判定に対応する getUpcomingNotionEvents の修正

### DIFF
--- a/app/Models/NotionModel.php
+++ b/app/Models/NotionModel.php
@@ -130,12 +130,6 @@ class NotionModel extends Model
             [
                 'property' => 'Date',
                 'date' => [
-                    'on_or_after' => $start_date,
-                ],
-            ],
-            [
-                'property' => 'Date',
-                'date' => [
                     'on_or_before' => $end_date,
                 ],
             ],
@@ -181,7 +175,32 @@ class NotionModel extends Model
             $startCursor = $data['next_cursor'] ?? null;
         } while (($data['has_more'] ?? false) && $startCursor !== null);
 
-        return collect($results);
+
+        $targetStart = new DateTime($start_date, new DateTimeZone(config('app.timezone')));
+        $targetEnd = new DateTime($end_date, new DateTimeZone(config('app.timezone')));
+
+        return collect($results)->filter(function (array $event) use ($targetStart, $targetEnd) {
+            $eventDate = $event['properties']['Date']['date'] ?? null;
+            if (!is_array($eventDate) || empty($eventDate['start'])) {
+                return false;
+            }
+
+            try {
+                $eventStart = new DateTime($eventDate['start'], new DateTimeZone(config('app.timezone')));
+            } catch (\Exception $e) {
+                return false;
+            }
+
+            $eventEndRaw = $eventDate['end'] ?? $eventDate['start'];
+            try {
+                $eventEnd = new DateTime($eventEndRaw, new DateTimeZone(config('app.timezone')));
+            } catch (\Exception $e) {
+                $eventEnd = clone $eventStart;
+            }
+
+            return $eventStart <= $targetEnd && $eventEnd >= $targetStart;
+        })->values();
+
     }
 
     /**

--- a/tests/Feature/BatchGoogleCalSyncNotionTest.php
+++ b/tests/Feature/BatchGoogleCalSyncNotionTest.php
@@ -363,6 +363,45 @@ class BatchGoogleCalSyncNotionTest extends TestCase
         Mail::assertNothingSent();
     }
 
+
+    public function test_command_does_not_re_register_existing_cross_period_multi_day_all_day_event(): void
+    {
+        $this->setDefaultCalendarConfig();
+        config()->set('app.sync_report_mail_to', 'notify@example.com');
+
+        $event = (object) [
+            'id' => 'event-cross-period',
+            'summary' => 'Golden Week Trip',
+            'start' => (object) ['date' => '2026-04-29'],
+            'end' => (object) ['date' => '2026-05-02'],
+        ];
+
+        NotionModelFake::$upcomingEventsReturn = collect([
+            $this->makeNotionEvent(
+                'notion-event-existing',
+                'event-cross-period',
+                'Personal Label',
+                '2026-04-29',
+                '2026-05-01',
+                'Golden Week Trip'
+            ),
+        ]);
+
+        GoogleCalendarModelFake::$eventLists = [
+            'calendar-personal' => [$event],
+        ];
+
+        Mail::fake();
+
+        $this->artisan('command:gcal-sync-notion')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->assertSame([], NotionModelFake::$registCalls);
+        $this->assertSame([], NotionModelFake::$deleteCalls);
+
+        Mail::assertNothingSent();
+    }
+
     public function test_command_keeps_existing_all_day_single_day_event_when_period_matches(): void
     {
         $this->setDefaultCalendarConfig();

--- a/tests/Feature/NotionModelTest.php
+++ b/tests/Feature/NotionModelTest.php
@@ -101,12 +101,6 @@ class NotionModelTest extends TestCase
                     [
                         'property' => 'Date',
                         'date' => [
-                            'on_or_after' => $start,
-                        ],
-                    ],
-                    [
-                        'property' => 'Date',
-                        'date' => [
                             'on_or_before' => $end,
                         ],
                     ],

--- a/tests/Unit/NotionModelHttpTest.php
+++ b/tests/Unit/NotionModelHttpTest.php
@@ -66,12 +66,6 @@ class NotionModelHttpTest extends TestCase
             [
                 'property' => 'Date',
                 'date' => [
-                    'on_or_after' => '2024-01-01',
-                ],
-            ],
-            [
-                'property' => 'Date',
-                'date' => [
                     'on_or_before' => '2024-01-31',
                 ],
             ],


### PR DESCRIPTION
### Motivation
- Notion の既存フィルタ（`on_or_after` と `on_or_before` を AND）では、対象期間の前に開始して期間中に継続するイベントや、期間中に開始して期間終了後まで継続するイベントを取りこぼし、Notion 側の既存イベントと比較したときに重複登録が発生する恐れがあったため。

### Description
- `NotionModel::getUpcomingNotionEvents()` を変更し、Notion へのクエリは `on_or_before` を使って候補を取得し、アプリ側で期間重なり判定を行うようにした（判定条件は `eventStart <= targetEnd && eventEnd >= targetStart`）。
- `tests/Feature/NotionModelTest.php` と `tests/Unit/NotionModelHttpTest.php` の期待リクエストペイロードを新しいフィルタ構造に合わせて更新した（`on_or_after` 条件を除去）。
- `tests/Feature/BatchGoogleCalSyncNotionTest.php` に、複数日終日イベント（例: `2026-04-29`〜`2026-05-01` 相当）が既存の場合に再登録されないことを検証するテスト `test_command_does_not_re_register_existing_cross_period_multi_day_all_day_event` を追加した。

### Testing
- 試行した自動テストコマンド: `php artisan test tests/Feature/NotionModelTest.php tests/Unit/NotionModelHttpTest.php tests/Feature/BatchGoogleCalSyncNotionTest.php` は、実行環境に `vendor/autoload.php` が存在しないため失敗し、テストは実行できなかった（依存未インストール）。
- 変更に合わせてテストコードの期待値を更新済みであり、ローカル／CI での依存インストール後に自動テストが通ることを想定している。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2cf662d1083328752d756cc8e3454)