### PR TITLE
Notion削除処理に同期ウィンドウ重複チェックを追加

### DIFF
--- a/app/Console/Commands/BatchGoogleCalSyncNotion.php
+++ b/app/Console/Commands/BatchGoogleCalSyncNotion.php
@@ -137,6 +137,10 @@ class BatchGoogleCalSyncNotion extends Command
 
         $targetDateStart = $globalStart ?? $defaultTargetDateStart;
         $targetDateEnd = $globalEnd ?? $defaultTargetDateEnd;
+        $syncWindow = [
+            'start' => $targetDateStart,
+            'end' => $targetDateEnd,
+        ];
 
         // Notionに登録されている指定範囲のイベントを取得
         try {
@@ -242,6 +246,9 @@ class BatchGoogleCalSyncNotion extends Command
 
                     $googleEventPeriod = $googleEventPeriodsById[$googleCalendarId] ?? null;
                     $notionEventPeriod = $this->formatNotionEventPeriod($notionEvent);
+                    if (!$this->isPeriodOverlapping($notionEventPeriod, $syncWindow)) {
+                        continue;
+                    }
 
                     if (!in_array($googleCalendarId, $googleEventIds, true)
                         || $googleEventPeriod === null
@@ -509,6 +516,38 @@ class BatchGoogleCalSyncNotion extends Command
             'start' => $start,
             'end' => $end,
         ];
+    }
+
+    private function isPeriodOverlapping(array $eventPeriod, array $windowPeriod): bool
+    {
+        $eventStart = $this->normalizePeriodBoundary($eventPeriod['start'] ?? '', true);
+        $eventEnd = $this->normalizePeriodBoundary($eventPeriod['end'] ?? '', false);
+        $windowStart = $this->normalizePeriodBoundary($windowPeriod['start'] ?? '', true);
+        $windowEnd = $this->normalizePeriodBoundary($windowPeriod['end'] ?? '', false);
+
+        if ($eventStart === null || $eventEnd === null || $windowStart === null || $windowEnd === null) {
+            return true;
+        }
+
+        return $eventStart <= $windowEnd && $eventEnd >= $windowStart;
+    }
+
+    private function normalizePeriodBoundary(string $value, bool $isStart): ?\DateTimeImmutable
+    {
+        if ($value === '') {
+            return null;
+        }
+
+        try {
+            if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) === 1) {
+                $suffix = $isStart ? ' 00:00:00' : ' 23:59:59';
+                return new \DateTimeImmutable($value . $suffix, new \DateTimeZone(config('app.timezone')));
+            }
+
+            return new \DateTimeImmutable($value, new \DateTimeZone(config('app.timezone')));
+        } catch (\Exception $e) {
+            return null;
+        }
     }
 
     private function formatNotionEventStart(array $notionEvent): string


### PR DESCRIPTION
### Motivation
- 同期ウィンドウ外の Notion イベントが削除判定に巻き込まれるのを防ぐため。

### Description
- `handle()` で決定した `$targetDateStart` / `$targetDateEnd` を `start`/`end` 形式の `$syncWindow` として保持するよう追加した。 
- Notion 削除ループで `formatNotionEventPeriod()` 取得直後に `isPeriodOverlapping($notionEventPeriod, $syncWindow)` を呼び出し、重ならないイベントは `continue` するよう変更した。 
- 期間比較用に `isPeriodOverlapping()` と日付文字列を `DateTimeImmutable` に正規化する `normalizePeriodBoundary()` を追加し、終日形式 `Y-m-d` は開始を `00:00:00`、終了を `23:59:59` として扱う実装を行った。 
- 正規化に失敗した場合は安全を優先して重複あり扱い（削除判定へ進む）とする動作にしている。 

### Testing
- `php -l app/Console/Commands/BatchGoogleCalSyncNotion.php` を実行して構文エラーがないことを確認した（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41467b9b88332814b4ff6443ee88e)