### PR TITLE
Notion API 2026-03-11に対応

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,7 +139,7 @@ NOTION_API_TOKEN=
 # 同期先データベースの ID
 NOTION_DATABASE_ID=database_id-of-your-database
 # 利用する Notion API バージョン
-NOTION_VERSION=2025-09-03
+NOTION_VERSION=2026-03-11
 # データソース ID (インテグレーションとデータベースを紐付けた ID)
 NOTION_DATA_SOURCE_ID=datasource_id-of-your-database
 

--- a/app/Console/Commands/NotionCheckConnection.php
+++ b/app/Console/Commands/NotionCheckConnection.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Throwable;
+
+class NotionCheckConnection extends Command
+{
+    private const MIN_NOTION_VERSION = '2025-09-03';
+
+    private const REQUIRED_PROPERTIES = [
+        'Name' => 'title',
+        'Date' => 'date',
+        'ジャンル' => 'multi_select',
+        'googleCalendarId' => 'rich_text',
+    ];
+
+    protected $signature = 'notion:check-connection';
+
+    protected $description = 'Validate Notion API version, data source resolution, and required calendar properties.';
+
+    public function handle(): int
+    {
+        try {
+            if (!$this->validateNotionVersion()) {
+                return self::FAILURE;
+            }
+
+            $notion = app('App\\Models\\NotionModel');
+
+            $dataSourceId = $notion->resolveCalendarDataSourceId();
+            if ($dataSourceId === '') {
+                $this->error('Notion data source resolution failed: resolved data source id is empty.');
+                return self::FAILURE;
+            }
+
+            $this->info('Notion data source resolved: ' . $dataSourceId);
+
+            $schema = $notion->getCalendarDataSourceSchema();
+            $properties = $schema['properties'] ?? null;
+            if (!is_array($properties)) {
+                $this->error('Notion schema validation failed: data source response does not include properties.');
+                return self::FAILURE;
+            }
+
+            foreach (self::REQUIRED_PROPERTIES as $name => $expectedType) {
+                if (!array_key_exists($name, $properties)) {
+                    $this->error("Notion schema validation failed: required property '{$name}' is missing.");
+                    return self::FAILURE;
+                }
+
+                $actualType = $properties[$name]['type'] ?? null;
+                if ($actualType !== $expectedType) {
+                    $actual = is_string($actualType) && $actualType !== '' ? $actualType : 'unknown';
+                    $this->error("Notion schema validation failed: property '{$name}' must be '{$expectedType}', actual '{$actual}'.");
+                    return self::FAILURE;
+                }
+            }
+
+            $this->info('Notion connection check passed.');
+            return self::SUCCESS;
+        } catch (Throwable $e) {
+            $this->error('Notion connection check failed: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+    }
+
+    private function validateNotionVersion(): bool
+    {
+        $version = (string) config('app.notion_version');
+
+        if ($version === '') {
+            $this->error('NOTION_VERSION is not configured. Set NOTION_VERSION=' . self::MIN_NOTION_VERSION . ' or later.');
+            return false;
+        }
+
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $version)) {
+            $this->error("NOTION_VERSION is invalid: '{$version}'. Expected YYYY-MM-DD.");
+            return false;
+        }
+
+        if (strcmp($version, self::MIN_NOTION_VERSION) < 0) {
+            $this->error("NOTION_VERSION must be " . self::MIN_NOTION_VERSION . " or later for Notion data source API. Current: '{$version}'.");
+            return false;
+        }
+
+        $this->info('NOTION_VERSION is valid: ' . $version);
+        return true;
+    }
+}

--- a/app/Models/NotionModel.php
+++ b/app/Models/NotionModel.php
@@ -21,6 +21,20 @@ class NotionModel extends Model
 
     private static $dataSourceIdCache = [];
 
+    public function resolveCalendarDataSourceId(): string
+    {
+        return $this->getDataSourceId();
+    }
+
+    public function getCalendarDataSourceSchema(): array
+    {
+        $dataSourceId = $this->getDataSourceId();
+        $response = $this->client->get('data_sources/' . $dataSourceId);
+        $data = json_decode($response->getBody(), true);
+
+        return is_array($data) ? $data : [];
+    }
+
     /**
      * NotionModel constructor.
      */
@@ -239,7 +253,7 @@ class NotionModel extends Model
     {
         $response = $this->client->patch('pages/' . $eventId, [
             'json' => [
-                'archived' => true,
+                'in_trash' => true,
             ],
         ]);
 

--- a/config/app.php
+++ b/config/app.php
@@ -244,7 +244,7 @@ return [
     */
     'notion_database_id_of_calendar' => env('NOTION_DATABASE_ID', null),
     'notion_api_token' => env('NOTION_API_TOKEN', null),
-    'notion_version' => env('NOTION_VERSION', '2025-09-03'),
+    'notion_version' => env('NOTION_VERSION', '2026-03-11'),
     'notion_data_source_id' => env('NOTION_DATA_SOURCE_ID'),
     'google_calendar_id_personal' => env('GOOGLE_CALENDAR_ID_PERSONAL', null),
     'google_calendar_id_holiday' => env('GOOGLE_CALENDAR_ID_HOLIDAY', null),

--- a/tests/Feature/NotionCheckConnectionCommandTest.php
+++ b/tests/Feature/NotionCheckConnectionCommandTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\NotionModel;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use ReflectionProperty;
+use Tests\TestCase;
+
+class NotionCheckConnectionCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.notion_api_token', 'test-token');
+        config()->set('app.notion_version', '2026-03-11');
+        config()->set('app.notion_database_id_of_calendar', 'test-database');
+        config()->set('app.notion_data_source_id', null);
+
+        $this->clearDataSourceCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearDataSourceCache();
+
+        parent::tearDown();
+    }
+
+    public function test_command_passes_when_version_dataSourceAndRequiredPropertiesAreValid(): void
+    {
+        $this->instance(NotionModel::class, $this->createModelWithResponses([
+            new Response(200, [], json_encode([
+                'data_sources' => [
+                    ['id' => 'resolved-data-source'],
+                ],
+            ])),
+            new Response(200, [], json_encode([
+                'properties' => $this->validProperties(),
+            ])),
+        ]));
+
+        $this->artisan('notion:check-connection')
+            ->expectsOutput('NOTION_VERSION is valid: 2026-03-11')
+            ->expectsOutput('Notion data source resolved: resolved-data-source')
+            ->expectsOutput('Notion connection check passed.')
+            ->assertExitCode(0);
+    }
+
+    public function test_command_fails_whenNotionVersionDoesNotSupportDataSources(): void
+    {
+        config()->set('app.notion_version', '2023-05-23');
+        $this->instance(NotionModel::class, $this->createModelWithResponses([]));
+
+        $this->artisan('notion:check-connection')
+            ->expectsOutput("NOTION_VERSION must be 2025-09-03 or later for Notion data source API. Current: '2023-05-23'.")
+            ->assertExitCode(1);
+    }
+
+    public function test_command_fails_whenDataSourceCannotBeResolved(): void
+    {
+        $this->instance(NotionModel::class, $this->createModelWithResponses([
+            new Response(200, [], json_encode([
+                'data_sources' => [],
+            ])),
+        ]));
+
+        $this->artisan('notion:check-connection')
+            ->expectsOutput('NOTION_VERSION is valid: 2026-03-11')
+            ->expectsOutput('Notion connection check failed: Unable to resolve Notion data source id for database test-database.')
+            ->assertExitCode(1);
+    }
+
+    public function test_command_fails_whenRequiredPropertyIsMissing(): void
+    {
+        $properties = $this->validProperties();
+        unset($properties['ジャンル']);
+
+        config()->set('app.notion_data_source_id', 'configured-data-source');
+        $this->instance(NotionModel::class, $this->createModelWithResponses([
+            new Response(200, [], json_encode([
+                'properties' => $properties,
+            ])),
+        ]));
+
+        $this->artisan('notion:check-connection')
+            ->expectsOutput('Notion data source resolved: configured-data-source')
+            ->expectsOutput("Notion schema validation failed: required property 'ジャンル' is missing.")
+            ->assertExitCode(1);
+    }
+
+    public function test_command_fails_whenRequiredPropertyTypeIsWrong(): void
+    {
+        $properties = $this->validProperties();
+        $properties['googleCalendarId']['type'] = 'title';
+
+        config()->set('app.notion_data_source_id', 'configured-data-source');
+        $this->instance(NotionModel::class, $this->createModelWithResponses([
+            new Response(200, [], json_encode([
+                'properties' => $properties,
+            ])),
+        ]));
+
+        $this->artisan('notion:check-connection')
+            ->expectsOutput("Notion schema validation failed: property 'googleCalendarId' must be 'rich_text', actual 'title'.")
+            ->assertExitCode(1);
+    }
+
+    private function createModelWithResponses(array $responses): NotionModel
+    {
+        $mockHandler = new MockHandler($responses);
+        $handlerStack = HandlerStack::create($mockHandler);
+
+        $client = new Client([
+            'handler' => $handlerStack,
+            'base_uri' => 'https://api.notion.com/v1/',
+            'headers' => [
+                'Authorization' => 'Bearer ' . config('app.notion_api_token'),
+                'Notion-Version' => config('app.notion_version'),
+                'Content-Type' => 'application/json',
+            ],
+        ]);
+
+        $model = new NotionModel();
+
+        $clientProperty = new ReflectionProperty(NotionModel::class, 'client');
+        $clientProperty->setAccessible(true);
+        $clientProperty->setValue($model, $client);
+
+        return $model;
+    }
+
+    private function validProperties(): array
+    {
+        return [
+            'Name' => ['type' => 'title', 'title' => []],
+            'Date' => ['type' => 'date', 'date' => []],
+            'ジャンル' => ['type' => 'multi_select', 'multi_select' => []],
+            'googleCalendarId' => ['type' => 'rich_text', 'rich_text' => []],
+        ];
+    }
+
+    private function clearDataSourceCache(): void
+    {
+        $property = new ReflectionProperty(NotionModel::class, 'dataSourceIdCache');
+        $property->setAccessible(true);
+        $property->setValue(null, []);
+    }
+}

--- a/tests/Unit/NotionModelHttpTest.php
+++ b/tests/Unit/NotionModelHttpTest.php
@@ -196,7 +196,7 @@ class NotionModelHttpTest extends TestCase
         $this->assertFalse($result);
     }
 
-    public function test_delete_notion_event_sends_archive_patch_request_and_returns_true_on_success(): void
+    public function test_delete_notion_event_sends_trash_patch_request_and_returns_true_on_success(): void
     {
         $history = [];
         $model = $this->createModelWithMockHandler([
@@ -213,7 +213,7 @@ class NotionModelHttpTest extends TestCase
         $this->assertSame('/v1/pages/notion-event-id', $request->getUri()->getPath());
 
         $body = json_decode((string) $request->getBody(), true);
-        $this->assertSame(['archived' => true], $body);
+        $this->assertSame(['in_trash' => true], $body);
     }
 
     private function createModelWithMockHandler(array $responses, array &$history): NotionModel


### PR DESCRIPTION
## 概要
- cron 実行前に Notion 接続を確認する `notion:check-connection` コマンドを追加
- Notion API の既定バージョンを `2026-03-11` に更新
- `2026-03-11` で削除された `archived` の代わりに `in_trash` を使うよう変更

## 背景
- Notion API `2026-03-11` ではページのアーカイブ指定が `archived` から `in_trash` に変更されているため
- cron 実行前に data source 解決と必須プロパティを検証できるようにするため

## 確認内容
- `git diff --cached --check`
- `php artisan test tests\Unit\NotionModelDataSourceTest.php tests\Unit\NotionModelHttpTest.php tests\Feature\NotionModelTest.php tests\Feature\NotionCheckConnectionCommandTest.php`

## 影響範囲
- Notion 接続確認用 artisan コマンド
- Notion API バージョンの既定値
- Notion ページ削除処理