### PR TITLE
SCP自動デプロイを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Hostinger
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
+        with:
+          php-version: '8.3'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install production dependencies
+        run: composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
+
+      - name: Harden generated directories
+        run: |
+          cp .htaccess vendor/.htaccess
+          mkdir -p bootstrap/cache storage/app storage/framework storage/logs
+          cp .htaccess bootstrap/cache/.htaccess
+          cp .htaccess storage/app/.htaccess
+          cp .htaccess storage/framework/.htaccess
+          cp .htaccess storage/logs/.htaccess
+
+      - name: Deploy by SCP
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1
+        with:
+          host: ${{ secrets.SCP_HOST }}
+          port: ${{ secrets.SCP_PORT }}
+          username: ${{ secrets.SCP_USER }}
+          key: ${{ secrets.SCP_PRIVATE_KEY }}
+          source: ".htaccess,app,artisan,bootstrap,composer.json,composer.lock,config,resources,routes,server.php,storage,vendor"
+          target: "/home/u685478147/public_html/public_html/notion_calendar_sync"
+          overwrite: true

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,8 @@
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,0 +1,8 @@
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/bootstrap/.htaccess
+++ b/bootstrap/.htaccess
@@ -1,0 +1,8 @@
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/config/.htaccess
+++ b/config/.htaccess
@@ -1,0 +1,8 @@
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/resources/.htaccess
+++ b/resources/.htaccess
@@ -1,0 +1,8 @@
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/routes/.htaccess
+++ b/routes/.htaccess
@@ -1,0 +1,8 @@
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/storage/.htaccess
+++ b/storage/.htaccess
@@ -1,0 +1,8 @@
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/tests/.htaccess
+++ b/tests/.htaccess
@@ -1,0 +1,8 @@
+Options -Indexes
+
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>


### PR DESCRIPTION
## 概要
- `main` への push 時に SCP で Hostinger へデプロイする GitHub Actions workflow を追加
- deploy 先を `/home/u685478147/public_html/public_html/notion_calendar_sync` に設定
- root と主要ディレクトリに `.htaccess` を追加し、Web からの直接アクセスと directory listing を拒否
- secret を扱う GitHub Actions を full-length commit SHA に pin

## 背景
- `main` にマージした際にソースコードを自動デプロイしたい
- 公開ディレクトリ配下へ配置するため、各ディレクトリへ直接 Web アクセスされても内部ファイルが露出しないようにする必要がある

## 確認内容
- `gh auth status`
- `gh repo view --json nameWithOwner,defaultBranchRef`
- `rg` による追加ファイル内の secret 混入確認
- `php artisan test` は実行したが失敗
  - 失敗理由: 既存の `config/database.php:62` にある `PDO::MYSQL_ATTR_SSL_CA` が PHP 8.5 で deprecated となり、PHPUnit 上で exit code 1 になっている
  - 結果: `32 deprecated`, `7 failed`

## 影響範囲
- GitHub Actions deploy workflow
- Hostinger への SCP deploy
- Apache `.htaccess` による Web アクセス拒否
- アプリケーション実行コードへの破壊的変更はなし